### PR TITLE
Add a TYPE_USE test class

### DIFF
--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
@@ -18,6 +18,7 @@ interface UType {
 
     return parse(returnType.toString());
   }
+
   /** Create the UType from the given String. */
   static UType parse(String rawType) {
     final var type = ProcessorUtils.trimAnnotations(rawType);

--- a/blackbox-test-records/pom.xml
+++ b/blackbox-test-records/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
     <dependency>
       <groupId>io.avaje</groupId>
+      <artifactId>validator-constraints</artifactId>
+      <version>1.0-RC7</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
       <version>1.1</version>
     </dependency>

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/TypeUse.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/TypeUse.java
@@ -1,0 +1,10 @@
+package io.avaje.recordbuilder.test;
+
+import java.util.Map;
+
+import io.avaje.recordbuilder.RecordBuilder;
+import io.avaje.validation.constraints.NotBlank;
+import io.avaje.validation.constraints.NotEmpty;
+
+@RecordBuilder
+public record TypeUse(@NotEmpty Map<@NotBlank String, @NotBlank String> map) {}

--- a/blackbox-test-records/src/main/java/module-info.java
+++ b/blackbox-test-records/src/main/java/module-info.java
@@ -4,5 +4,6 @@ import io.avaje.recordbuilder.test.DamageType;
 //@DefaultInit.Global(type = DamageType.class, value="DamageType.ENERGY")
 module io.avaje.spi.blackbox {
   requires io.avaje.record;
+  requires io.avaje.validation.contraints;
   requires java.compiler;
 }


### PR DESCRIPTION
it seems I've already used the trim annotations from prisms to cut out type-use annotations.
part of #19 