### PR TITLE
Propogate annotations to setters

### DIFF
--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordModel.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordModel.java
@@ -3,19 +3,16 @@ package io.avaje.recordbuilder.internal;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.joining;
 
-import java.lang.invoke.VarHandle;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.PrimitiveType;
-import javax.lang.model.type.TypeMirror;
 
 final class RecordModel {
 
@@ -82,7 +79,10 @@ final class RecordModel {
       builder.append(
           "  private %s %s%s;\n"
               .formatted(
-                  uType.shortType().transform(ProcessorUtils::trimAnnotations),
+                  uType
+                      .shortType()
+                      .transform(ProcessorUtils::trimAnnotations)
+                      .transform(this::shortRawType),
                   element.getSimpleName(),
                   defaultVal));
     }
@@ -97,5 +97,17 @@ final class RecordModel {
         .transform(s -> s + (isImported ? "\nimport " + type.getQualifiedName() + ";" : ""))
         .lines()
         .collect(joining("\n"));
+  }
+
+  private String shortRawType(String rawType) {
+    final Map<String, String> typeMap = new LinkedHashMap<>();
+    for (final String val : importTypes) {
+      typeMap.put(val, ProcessorUtils.shortType(val));
+    }
+    String shortRaw = rawType;
+    for (final Map.Entry<String, String> entry : typeMap.entrySet()) {
+      shortRaw = shortRaw.replace(entry.getKey(), entry.getValue());
+    }
+    return shortRaw;
   }
 }

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordProcessor.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordProcessor.java
@@ -1,22 +1,20 @@
 package io.avaje.recordbuilder.internal;
 
-import static io.avaje.recordbuilder.internal.Templates.*;
-import static io.avaje.recordbuilder.internal.APContext.asTypeElement;
 import static io.avaje.recordbuilder.internal.APContext.createSourceFile;
 import static io.avaje.recordbuilder.internal.APContext.elements;
 import static io.avaje.recordbuilder.internal.APContext.getModuleInfoReader;
 import static io.avaje.recordbuilder.internal.APContext.logError;
 import static io.avaje.recordbuilder.internal.APContext.typeElement;
-import static java.util.stream.Collectors.joining;
+import static io.avaje.recordbuilder.internal.Templates.methodAdd;
+import static io.avaje.recordbuilder.internal.Templates.methodGetter;
+import static io.avaje.recordbuilder.internal.Templates.methodPut;
+import static io.avaje.recordbuilder.internal.Templates.methodSetter;
+import static io.avaje.recordbuilder.internal.Templates.transformers;
 import static java.util.stream.Collectors.toMap;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.text.MessageFormat;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -127,18 +125,17 @@ public final class RecordProcessor extends AbstractProcessor {
       }
 
       if (APContext.isAssignable(type.mainType(), "java.util.Collection")) {
-        String param0 = type.param0();
-        String param0ShortType = UType.parse(param0).shortType();
+
+        String param0ShortType = type.param0().shortType();
         Name simpleName = element.getSimpleName();
         writer.append(
             methodAdd(simpleName.toString(), type.shortType(), shortName, param0ShortType));
       }
 
       if (APContext.isAssignable(type.mainType(), "java.util.Map")) {
-        String param0 = type.param0();
-        String param0ShortType = UType.parse(param0).shortType();
-        String param1 = type.param1();
-        String param1ShortType = UType.parse(param1).shortType();
+
+        String param0ShortType =  type.param0().shortType();
+        String param1ShortType = type.param1().shortType();
         Name simpleName = element.getSimpleName();
         writer.append(
             methodPut(

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordProcessor.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordProcessor.java
@@ -121,7 +121,11 @@ public final class RecordProcessor extends AbstractProcessor {
       final var type = UType.parse(element.asType());
       writer.append(methodSetter(element.getSimpleName(), type.shortType(), shortName));
       if (getters) {
-        writer.append(methodGetter(element.getSimpleName(), type.shortType(), shortName));
+        writer.append(
+            methodGetter(
+                element.getSimpleName(),
+                type.shortType().transform(ProcessorUtils::trimAnnotations),
+                shortName));
       }
 
       if (APContext.isAssignable(type.mainType(), "java.util.Collection")) {
@@ -134,13 +138,13 @@ public final class RecordProcessor extends AbstractProcessor {
 
       if (APContext.isAssignable(type.mainType(), "java.util.Map")) {
 
-        String param0ShortType =  type.param0().shortType();
+        String param0ShortType = type.param0().shortType();
         String param1ShortType = type.param1().shortType();
         Name simpleName = element.getSimpleName();
         writer.append(
             methodPut(
                 simpleName.toString(),
-                type.shortType(),
+                type.shortType().transform(ProcessorUtils::trimAnnotations),
                 shortName,
                 param0ShortType,
                 param1ShortType));

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/TypeMirrorVisitor.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/TypeMirrorVisitor.java
@@ -225,6 +225,7 @@ public class TypeMirrorVisitor extends AbstractTypeVisitor9<StringBuilder, Strin
       return element.getQualifiedName().toString();
     }
     final StringBuilder sb = new StringBuilder();
+    // if not too nested write annotations before the fqn like
     if (depth < 3) {
       for (final var ta : typeUseAnnotations) {
         sb.append(ta.toString()).append(" ");
@@ -238,6 +239,8 @@ public class TypeMirrorVisitor extends AbstractTypeVisitor9<StringBuilder, Strin
       enclosedPart = "";
     }
     sb.append(enclosedPart);
+
+    // if too nested write annotations within the fqn
     if (depth > 2) {
       for (final var ta : typeUseAnnotations) {
         sb.append(ta.toString()).append(" ");

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/TypeMirrorVisitor.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/TypeMirrorVisitor.java
@@ -1,0 +1,322 @@
+package io.avaje.recordbuilder.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.QualifiedNameable;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.IntersectionType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.NullType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.UnionType;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.AbstractTypeVisitor9;
+
+// TODO make this not ugly
+public class TypeMirrorVisitor extends AbstractTypeVisitor9<StringBuilder, StringBuilder>
+    implements UType {
+
+  private final int depth;
+
+  private final boolean includeAnnotations;
+
+  private final Map<TypeVariable, String> typeVariables;
+  private Set<String> allTypes = new HashSet<>();
+  private String mainType;
+  private String fullType;
+  private final List<UType> params = new ArrayList<>();
+  private final List<AnnotationMirror> annotations = new ArrayList<>();
+  private List<AnnotationMirror> everyAnnotation = new ArrayList<>();
+
+  public static TypeMirrorVisitor create(TypeMirror typeMirror) {
+    final var v = new TypeMirrorVisitor(1, Map.of());
+    final StringBuilder b = new StringBuilder();
+    v.fullType = typeMirror.accept(v, b).toString();
+    return v;
+  }
+
+  TypeMirrorVisitor() {
+    this(1, new HashMap<>());
+  }
+
+  @Override
+  public Set<String> importTypes() {
+    return allTypes;
+  }
+
+  @Override
+  public String shortType() {
+
+    return shortRawType(fullType, allTypes);
+  }
+
+  @Override
+  public String full() {
+    return fullType;
+  }
+
+  @Override
+  public boolean isGeneric() {
+    return fullType.contains("<");
+  }
+
+  @Override
+  public List<UType> genericParams() {
+    return params;
+  }
+
+  @Override
+  public List<AnnotationMirror> annotations() {
+    return annotations;
+  }
+
+  @Override
+  public List<AnnotationMirror> allAnnotationsInType() {
+    return everyAnnotation;
+  }
+
+  @Override
+  public String mainType() {
+    return mainType;
+  }
+
+  @Override
+  public UType param0() {
+    return params.isEmpty() ? null : params.get(0);
+  }
+
+  @Override
+  public UType param1() {
+    return allTypes.size() < 2 ? null : params.get(1);
+  }
+
+  private static String shortRawType(String rawType, Set<String> allTypes) {
+    final Map<String, String> typeMap = new LinkedHashMap<>();
+    for (final String val : allTypes) {
+      typeMap.put(val, ProcessorUtils.shortType(val));
+    }
+    String shortRaw = rawType;
+    for (final Map.Entry<String, String> entry : typeMap.entrySet()) {
+      shortRaw = shortRaw.replace(entry.getKey(), entry.getValue());
+    }
+    return shortRaw;
+  }
+
+  private TypeMirrorVisitor(int depth, Map<TypeVariable, String> typeVariables) {
+    this.includeAnnotations = true;
+    this.depth = depth;
+    this.typeVariables = new HashMap<>();
+    this.typeVariables.putAll(typeVariables);
+  }
+
+  private void child(TypeMirror ct, StringBuilder p) {
+
+    var child = new TypeMirrorVisitor(depth + 1, typeVariables);
+    child.allTypes = allTypes;
+    child.everyAnnotation = everyAnnotation;
+    var full = ct.accept(child, new StringBuilder()).toString();
+    child.fullType = full;
+    params.add(child);
+    p.append(full);
+  }
+
+  @Override
+  public StringBuilder visitPrimitive(PrimitiveType t, StringBuilder p) {
+
+    if (includeAnnotations) {
+      for (final var ta : t.getAnnotationMirrors()) {
+        p.append(ta.toString()).append(" ");
+        annotations.add(ta);
+        everyAnnotation.add(ta);
+      }
+    }
+    p.append(t.getKind().toString().toLowerCase(Locale.ROOT));
+
+    return p;
+  }
+
+  @Override
+  public StringBuilder visitNull(NullType t, StringBuilder p) {
+    return p;
+  }
+
+  @Override
+  public StringBuilder visitArray(ArrayType t, StringBuilder p) {
+    final var ct = t.getComponentType();
+    child(ct, p);
+    boolean first = true;
+    if (includeAnnotations) {
+      for (final var ta : t.getAnnotationMirrors()) {
+        if (first) {
+          p.append(" ");
+          first = false;
+        }
+        p.append(ta.toString()).append(" ");
+        annotations.add(ta);
+        everyAnnotation.add(ta);
+      }
+    }
+    p.append("[]");
+    return p;
+  }
+
+  @Override
+  public StringBuilder visitDeclared(DeclaredType t, StringBuilder p) {
+    final String fqn = fullyQualfiedName(t, includeAnnotations);
+    var trimmed = fullyQualfiedName(t, false);
+    if (!fqn.startsWith("java.lang")) {
+      allTypes.add(Utils.extractTypeWithNest(trimmed));
+    }
+    if (this.mainType == null) {
+      mainType = trimmed;
+    }
+    p.append(fqn);
+    final var tas = t.getTypeArguments();
+    if (!tas.isEmpty()) {
+      p.append("<");
+      boolean first = true;
+      for (final var ta : tas) {
+        if (!first) {
+          p.append(", ");
+        }
+        child(ta, p);
+        first = false;
+      }
+      p.append(">");
+    }
+    return p;
+  }
+
+  String fullyQualfiedName(DeclaredType t, boolean includeAnnotations) {
+    final TypeElement element = (TypeElement) t.asElement();
+    final var typeUseAnnotations = t.getAnnotationMirrors();
+    for (final var ta : typeUseAnnotations) {
+      final TypeElement annotation = (TypeElement) ta.getAnnotationType().asElement();
+      allTypes.add(annotation.getQualifiedName().toString());
+      annotations.add(ta);
+      everyAnnotation.add(ta);
+    }
+    if (typeUseAnnotations.isEmpty() || !includeAnnotations) {
+      return element.getQualifiedName().toString();
+    }
+    final StringBuilder sb = new StringBuilder();
+    if (depth < 3) {
+      for (final var ta : typeUseAnnotations) {
+        sb.append(ta.toString()).append(" ");
+      }
+    }
+    String enclosedPart;
+    final Element enclosed = element.getEnclosingElement();
+    if (enclosed instanceof final QualifiedNameable qn) {
+      enclosedPart = qn.getQualifiedName().toString() + ".";
+    } else {
+      enclosedPart = "";
+    }
+    sb.append(enclosedPart);
+    if (depth > 2) {
+      for (final var ta : typeUseAnnotations) {
+        sb.append(ta.toString()).append(" ");
+      }
+    }
+
+    sb.append(element.getSimpleName());
+    return sb.toString();
+  }
+
+  @Override
+  public StringBuilder visitError(ErrorType t, StringBuilder p) {
+    return p;
+  }
+
+  @Override
+  public StringBuilder visitTypeVariable(TypeVariable t, StringBuilder p) {
+    /*
+     * Types can be recursive so we have to check if we have already done this type.
+     */
+    final String previous = typeVariables.get(t);
+
+    if (previous != null) {
+      p.append(previous);
+      return p;
+    }
+    final StringBuilder sb = new StringBuilder();
+    /*
+     * We do not have to print the upper and lower bound as those are defined usually
+     * on the method.
+     */
+    if (includeAnnotations) {
+      for (final var ta : t.getAnnotationMirrors()) {
+        p.append(ta.toString()).append(" ");
+        sb.append(ta.toString()).append(" ");
+      }
+    }
+    p.append(t.asElement().getSimpleName().toString());
+    sb.append(t.asElement().getSimpleName().toString());
+    typeVariables.put(t, sb.toString());
+
+    return p;
+  }
+
+  @Override
+  public StringBuilder visitWildcard(WildcardType t, StringBuilder p) {
+    final var extendsBound = t.getExtendsBound();
+    final var superBound = t.getSuperBound();
+    for (final var ta : t.getAnnotationMirrors()) {
+      p.append(ta.toString()).append(" ");
+    }
+    if (extendsBound != null) {
+      p.append("? extends ");
+      child(extendsBound, p);
+    } else if (superBound != null) {
+      p.append("? super ");
+      child(superBound, p);
+    } else {
+      p.append("?");
+    }
+    return p;
+  }
+
+  @Override
+  public StringBuilder visitExecutable(ExecutableType t, StringBuilder p) {
+    throw new UnsupportedOperationException("don't support executables");
+  }
+
+  @Override
+  public StringBuilder visitNoType(NoType t, StringBuilder p) {
+    throw new UnsupportedOperationException("don't support NoType");
+  }
+
+  @Override
+  public StringBuilder visitIntersection(IntersectionType t, StringBuilder p) {
+    boolean first = true;
+    for (final var b : t.getBounds()) {
+      if (first) {
+        first = false;
+      } else {
+        p.append("&");
+      }
+      child(b, p);
+    }
+    return p;
+  }
+
+  @Override
+  public StringBuilder visitUnion(UnionType t, StringBuilder p) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/TypeMirrorVisitor.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/TypeMirrorVisitor.java
@@ -145,7 +145,12 @@ public class TypeMirrorVisitor extends AbstractTypeVisitor9<StringBuilder, Strin
         everyAnnotation.add(ta);
       }
     }
-    p.append(t.getKind().toString().toLowerCase(Locale.ROOT));
+
+    var primitiveStr = t.getKind().toString().toLowerCase(Locale.ROOT);
+    if (this.mainType == null) {
+      mainType = primitiveStr;
+    }
+    p.append(primitiveStr);
 
     return p;
   }
@@ -157,6 +162,8 @@ public class TypeMirrorVisitor extends AbstractTypeVisitor9<StringBuilder, Strin
 
   @Override
   public StringBuilder visitArray(ArrayType t, StringBuilder p) {
+
+    boolean mainUnset = this.mainType == null;
     final var ct = t.getComponentType();
     child(ct, p);
     boolean first = true;
@@ -172,6 +179,9 @@ public class TypeMirrorVisitor extends AbstractTypeVisitor9<StringBuilder, Strin
       }
     }
     p.append("[]");
+    if (mainUnset) {
+      mainType += "[]";
+    }
     return p;
   }
 
@@ -245,6 +255,7 @@ public class TypeMirrorVisitor extends AbstractTypeVisitor9<StringBuilder, Strin
 
   @Override
   public StringBuilder visitTypeVariable(TypeVariable t, StringBuilder p) {
+
     /*
      * Types can be recursive so we have to check if we have already done this type.
      */

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
@@ -1,14 +1,9 @@
 package io.avaje.recordbuilder.internal;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.StringJoiner;
 
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeMirror;
 
 interface UType {
@@ -16,17 +11,7 @@ interface UType {
   /** Create the UType from the given TypeMirror. */
   static UType parse(TypeMirror returnType) {
 
-    return parse(returnType.toString());
-  }
-
-  /** Create the UType from the given String. */
-  static UType parse(String rawType) {
-    final var type = ProcessorUtils.trimAnnotations(rawType);
-    final int pos = type.indexOf('<');
-    if (pos == -1) {
-      return new UType.Basic(type);
-    }
-    return new UType.Generic(type);
+    return TypeMirrorVisitor.create(returnType);
   }
 
   /** Return the import types. */
@@ -39,12 +24,12 @@ interface UType {
   String mainType();
 
   /** Return the first generic parameter. */
-  default String param0() {
+  default UType param0() {
     return null;
   }
 
   /** Return the second generic parameter. */
-  default String param1() {
+  default UType param1() {
     return null;
   }
 
@@ -60,153 +45,15 @@ interface UType {
     return false;
   }
 
-  default String genericParams() {
-    return "";
+  default List<UType> genericParams() {
+    return List.of();
   }
 
-  /** Simple non-generic type. */
-  class Basic implements UType {
-    final String rawType;
-
-    Basic(String rawType) {
-      this.rawType = rawType;
-    }
-
-    @Override
-    public String full() {
-      return rawType;
-    }
-
-    @Override
-    public Set<String> importTypes() {
-      return rawType.startsWith("java.lang.") && rawType.indexOf('.') > -1
-          ? Set.of()
-          : Collections.singleton(rawType.replace("[]", ""));
-    }
-
-    @Override
-    public String shortType() {
-      return ProcessorUtils.shortType(rawType);
-    }
-
-    @Override
-    public String mainType() {
-      return rawType;
-    }
-
-    @Override
-    public String toString() {
-      return rawType;
-    }
+  default List<AnnotationMirror> annotations() {
+    return List.of();
   }
 
-  /** Generic type. */
-  class Generic implements UType {
-    final String rawType;
-    final List<String> allTypes;
-    final String shortRawType;
-
-    Generic(String rawTypeInput) {
-      this.rawType = rawTypeInput.replace(" ", ""); // trim whitespace
-      this.allTypes = Arrays.asList(rawType.split("[<|>|,]"));
-      this.shortRawType = shortRawType(rawType, allTypes);
-    }
-
-    private String shortRawType(String rawType, List<String> allTypes) {
-      final Map<String, String> typeMap = new LinkedHashMap<>();
-      for (final String val : allTypes) {
-        typeMap.put(val, ProcessorUtils.shortType(val));
-      }
-      String shortRaw = rawType;
-      for (final Map.Entry<String, String> entry : typeMap.entrySet()) {
-        shortRaw = shortRaw.replace(entry.getKey(), entry.getValue());
-      }
-      return shortRaw;
-    }
-
-    @Override
-    public String full() {
-      return rawType;
-    }
-
-    @Override
-    public String toString() {
-      return rawType;
-    }
-
-    @Override
-    public Set<String> importTypes() {
-      final Set<String> set = new LinkedHashSet<>();
-      for (final String type : allTypes) {
-        if (!type.startsWith("java.lang.") && type.indexOf('.') > -1) {
-          if (type.startsWith("java")) {
-            set.add(type.replace("[]", "").replace("?extends", ""));
-          } else {
-            set.add(innerTypesImport(type).replace("[]", "").replace("?extends", ""));
-          }
-        }
-      }
-      set.remove("?");
-      return set;
-    }
-
-    public String innerTypesImport(String type) {
-      final var parts = type.split("\\.");
-      var result = "";
-      var foundUpper = false;
-
-      for (var i = 0; i < parts.length; i++) {
-        if (!Character.isUpperCase(parts[i].charAt(0))) {
-          result += parts[i] + ".";
-        } else if (!foundUpper) {
-          foundUpper = true;
-          result += parts[i] + (i == parts.length - 1 ? "" : ".");
-        } else {
-          break;
-        }
-      }
-
-      if (result.endsWith(".")) {
-        result = result.substring(0, result.length() - 1);
-      }
-      return result;
-    }
-
-    @Override
-    public boolean isGeneric() {
-      return true;
-    }
-
-    @Override
-    public String genericParams() {
-      final StringJoiner joiner = new StringJoiner(",");
-      for (final String type : allTypes) {
-        if (type.indexOf('.') == -1) {
-          joiner.add(type);
-        }
-      }
-      final String commaDelim = joiner.toString();
-      return commaDelim.isEmpty() ? "" : "<" + commaDelim + "> ";
-    }
-
-    @Override
-    public String shortType() {
-      return shortRawType;
-    }
-
-    @Override
-    public String mainType() {
-      return allTypes.isEmpty() ? null : allTypes.get(0);
-    }
-
-    @Override
-    public String param0() {
-      return allTypes.size() < 2 ? null : allTypes.get(1);
-    }
-
-    @Override
-    public String param1() {
-      return allTypes.size() < 3 ? null : allTypes.get(2);
-    }
+  default List<AnnotationMirror> allAnnotationsInType() {
+    return List.of();
   }
 }

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
@@ -58,4 +58,6 @@ interface UType {
   default List<AnnotationMirror> allAnnotationsInType() {
     return List.of();
   }
+
+  String fullWithoutAnnotations();
 }

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
@@ -23,6 +23,9 @@ interface UType {
   /** Return the main type (outer most type). */
   String mainType();
 
+  /** Return the full type as a string. */
+  String full();
+
   /** Return the first generic parameter. */
   default UType param0() {
     return null;
@@ -38,26 +41,32 @@ interface UType {
     return null;
   }
 
-  /** Return the raw type. */
-  String full();
-
   default boolean isGeneric() {
     return false;
   }
 
-  /** Return the generic param UType for the parameters. */
+  /** Return the UTypes for the generic parameters. */
   default List<UType> genericParams() {
     return List.of();
   }
-  /** Return the annonataion mirrors directly on the type. */
+
+  /** Return the annotation mirrors directly on the type. */
   default List<AnnotationMirror> annotations() {
     return List.of();
   }
 
-  /** Return the annonataion mirrors directly on the type and in generic type use. */
+  /** Return the annotation mirrors directly on the type and in generic type use. */
   default List<AnnotationMirror> allAnnotationsInType() {
     return List.of();
   }
 
-  String fullWithoutAnnotations();
+  /** Return the full type as a string stripped of annotations. */
+  default String fullWithoutAnnotations() {
+    return ProcessorUtils.trimAnnotations(full());
+  }
+
+  /** Return the short type as a string stripped of annotations. */
+  default String shortWithoutAnnotations() {
+    return ProcessorUtils.trimAnnotations(shortType());
+  }
 }

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
@@ -4,27 +4,51 @@ import java.util.List;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
-interface UType {
+/** Utility type to help process {@link TypeMirror}s */
+public interface UType {
 
-  /** Create the UType from the given TypeMirror. */
-  static UType parse(TypeMirror returnType) {
+  /**
+   * Create a UType from the given TypeMirror.
+   *
+   * @param mirror type mirror to analyze
+   * @return Create the UType from the given TypeMirror.
+   */
+  static UType parse(TypeMirror mirror) {
 
-    return TypeMirrorVisitor.create(returnType);
+    return TypeMirrorVisitor.create(mirror);
   }
 
-  /** Return the import types. */
+  /**
+   * Return all the import types needed to write this mirror in source code (annotations included).
+   *
+   * @return Return the import types required.
+   */
   Set<String> importTypes();
 
-  /** Return the short name. */
-  String shortType();
+  /**
+   * Return the full type as a code safe string. (with annotations if present)
+   *
+   * @return the full typeName
+   */
+  String full();
 
-  /** Return the main type (outer most type). */
+  /**
+   *  Return the main type (outermost type). e.g for mirror {@ java.util.List<Something> you'll get java.util.List
+   *
+   * @return the outermost type
+   */
   String mainType();
 
-  /** Return the full type as a string. */
-  String full();
+  /**
+   * Return the full (but unqualified) type as a code safe string. Use in tandem with {@link
+   * #importTypes()} to generate readable code
+   *
+   * @return the short name with unqualified type
+   */
+  String shortType();
 
   /** Return the first generic parameter. */
   default UType param0() {
@@ -36,37 +60,76 @@ interface UType {
     return null;
   }
 
-  /** Return the raw generic parameter if this UType is a Collection. */
-  default UType paramRaw() {
-    return null;
+  /**
+   * Retrieve the component types associated with this mirror.
+   *
+   * <p>The annotated class must conform to the service provider specification. Specifically, it
+   * must:
+   *
+   * <ul>
+   *   <li>{@code TypeKind.ARRAY}: will contain the array componentType
+   *   <li>{@code TypeKind.DECLARED}: will contain the generic parameters
+   *   <li>{@code TypeKind.TYPEVAR}: will contain the upper bound for the type variable
+   *   <li>{@code TypeKind.WILDCARD}: will contain the extends bound or super bound
+   *   <li>{@code TypeKind.INTERSECTION}: will contain the bounds of the intersection
+   * </ul>
+   *
+   * @return the component types
+   */
+  default List<UType> componentTypes() {
+    return List.of();
   }
 
+  /**
+   * The kind of the type mirror used to create this Utype.
+   *
+   * @return the typekind
+   */
+  TypeKind kind();
+
+  /**
+   * Returns whether the type mirror is generic
+   *
+   * @return whether the type is generic
+   */
   default boolean isGeneric() {
     return false;
   }
 
-  /** Return the UTypes for the generic parameters. */
-  default List<UType> genericParams() {
-    return List.of();
-  }
-
-  /** Return the annotation mirrors directly on the type. */
+  /**
+   * Return the annotation mirrors directly on the type.
+   *
+   * @return the annotations directly present
+   */
   default List<AnnotationMirror> annotations() {
     return List.of();
   }
 
-  /** Return the annotation mirrors directly on the type and in generic type use. */
+  /**
+   * Return the annotation mirrors directly on the type and in within generic type use. e.g. for
+   * {@code @NotEmpty Map<@Notblank String, Object>} you will get all the annotations not just
+   *
+   * @return all annotations present on this type
+   */
   default List<AnnotationMirror> allAnnotationsInType() {
     return List.of();
   }
 
-  /** Return the full type as a string stripped of annotations. */
+  /**
+   * Return the full type as a string, stripped of annotations.
+   *
+   * @return full type, but without annotations
+   */
   default String fullWithoutAnnotations() {
-    return ProcessorUtils.trimAnnotations(full());
+    return ProcessorUtils.trimAnnotations(full()).replace(",", ", ");
   }
 
-  /** Return the short type as a string stripped of annotations. */
+  /**
+   * Return the short type as a string, stripped of annotations.
+   *
+   * @return short type, but without annotations
+   */
   default String shortWithoutAnnotations() {
-    return ProcessorUtils.trimAnnotations(shortType());
+    return ProcessorUtils.trimAnnotations(shortType()).replace(",", ", ");
   }
 }

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/UType.java
@@ -45,14 +45,16 @@ interface UType {
     return false;
   }
 
+  /** Return the generic param UType for the parameters. */
   default List<UType> genericParams() {
     return List.of();
   }
-
+  /** Return the annonataion mirrors directly on the type. */
   default List<AnnotationMirror> annotations() {
     return List.of();
   }
 
+  /** Return the annonataion mirrors directly on the type and in generic type use. */
   default List<AnnotationMirror> allAnnotationsInType() {
     return List.of();
   }

--- a/avaje-record-builder/src/main/java/io/avaje/recordbuilder/DefaultInit.java
+++ b/avaje-record-builder/src/main/java/io/avaje/recordbuilder/DefaultInit.java
@@ -2,6 +2,7 @@ package io.avaje.recordbuilder;
 
 import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.RECORD_COMPONENT;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
@@ -10,7 +11,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Retention(SOURCE)
-@Target({RECORD_COMPONENT})
+@Target({RECORD_COMPONENT, PARAMETER})
 public @interface DefaultInit {
 
   /** Specify how the default value should be initialized */

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/TypeUse.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/TypeUse.java
@@ -3,8 +3,10 @@ package io.avaje.recordbuilder.test;
 import java.util.Map;
 
 import io.avaje.recordbuilder.RecordBuilder;
+import io.avaje.recordbuilder.test.Raven.Weapon;
 import io.avaje.validation.constraints.NotBlank;
 import io.avaje.validation.constraints.NotEmpty;
 
 @RecordBuilder
-public record TypeUse(@NotEmpty Map<@NotBlank String, @NotBlank String> map) {}
+public record TypeUse(
+    @NotEmpty @NotBlank Map<@NotBlank(groups = Weapon.class) String, @NotEmpty(groups = Weapon.class) Map<@NotBlank(groups = Weapon.class) Weapon, @NotBlank Raven>> map) {}

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/TypeUse.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/TypeUse.java
@@ -9,4 +9,9 @@ import io.avaje.validation.constraints.NotEmpty;
 
 @RecordBuilder
 public record TypeUse(
-    @NotEmpty @NotBlank Map<@NotBlank(groups = Weapon.class) String, @NotEmpty(groups = Weapon.class) Map<@NotBlank(groups = Weapon.class) Weapon, @NotBlank Raven>> map) {}
+    @NotEmpty @NotBlank
+        Map<
+                @NotBlank(groups = Weapon.class) String,
+                @NotEmpty(groups = Weapon.class) Map<
+                    @NotBlank(groups = Weapon.class) Weapon, @NotBlank Raven>>
+            map) {}


### PR DESCRIPTION
Add that cool Visitor thing that @agentgt so graciously provided.

now for 
```java
@RecordBuilder
public record TypeUse(
    @NotEmpty @NotBlank
        Map<
                @NotBlank(groups = Weapon.class) String,
                @NotEmpty(groups = Weapon.class) Map<
                    @NotBlank(groups = Weapon.class) Weapon, @NotBlank Raven>>
            map) {}
```

will generate setters like this: (minus the formatting) 

```java
  /** Set a new value for {@code map}. */
  public TypeUseBuilder map(
      @NotEmpty @NotBlank
          Map<
                  @NotBlank(groups = {Raven.Weapon.class}) String,
                  @NotEmpty(groups = {Raven.Weapon.class}) Map<
                      Raven.@NotBlank(groups = {Raven.Weapon.class}) Weapon,
                      io.avaje.recordbuilder.test.@NotBlank Raven>>
              map) {
    this.map = map;
    return this;
  }
```
fixes #19 