### PR TITLE
Remove transform() method?

### DIFF
--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordProcessor.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordProcessor.java
@@ -9,7 +9,6 @@ import static io.avaje.recordbuilder.internal.Templates.methodAdd;
 import static io.avaje.recordbuilder.internal.Templates.methodGetter;
 import static io.avaje.recordbuilder.internal.Templates.methodPut;
 import static io.avaje.recordbuilder.internal.Templates.methodSetter;
-import static io.avaje.recordbuilder.internal.Templates.transformers;
 import static java.util.stream.Collectors.toMap;
 
 import java.io.IOException;
@@ -114,8 +113,6 @@ public final class RecordProcessor extends AbstractProcessor {
       Boolean writeGetters) {
 
     boolean getters = Boolean.TRUE.equals(writeGetters);
-
-    writer.append(transformers(shortName));
 
     for (final var element : components) {
       final var type = UType.parse(element.asType());

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/Templates.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/Templates.java
@@ -58,21 +58,6 @@ public class Templates {
         packageName, imports, shortName, fields, constructor, constructorBody, builderFrom, build);
   }
 
-  static String transformers(String shortName) {
-    return MessageFormat.format(
-        """
-		     /**
-		      * Modify this builder with the given consumer
-		      */
-		     public {0}Builder transform(Consumer<{0}Builder> builder{0}) '{'
-		         builder{0}.accept(this);
-		         return this;
-		     '}'
-
-		   """,
-        shortName.replace(".", "$"));
-  }
-
   static String methodSetter(CharSequence componentName, String type, String shortName) {
     return MessageFormat.format(
         """

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/Order.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/Order.java
@@ -1,13 +1,14 @@
 package io.avaje.recordbuilder.test;
 
 import io.avaje.recordbuilder.RecordBuilder;
+import io.avaje.validation.constraints.NotNull;
 
 import java.util.List;
 
 @RecordBuilder(getters = true)
 public record Order(
   long id,
-  Status status,
+  @NotNull Status status,
   Customer customer,
   List<OrderLine> lines
 ) {

--- a/blackbox-test-records/src/test/java/io/avaje/recordbuilder/test/OrderTest.java
+++ b/blackbox-test-records/src/test/java/io/avaje/recordbuilder/test/OrderTest.java
@@ -44,22 +44,25 @@ class OrderTest {
       .status(Order.Status.NEW)
       .build();
 
-    var transformedOrder =
-      Order.from(original)
-        .transform(orderBuilder -> {
-          if (orderBuilder.status() == Order.Status.NEW) {
-            orderBuilder.status(Order.Status.COMPLETE);
-
-            // transform a nested collection
-            List<OrderLine> newLines = orderBuilder.lines().stream()
-              .filter(line -> line.id() < 43)
-              .toList();
-
-            orderBuilder.lines(newLines);
-          }
-        })
-        .build();
+    Order transformedOrder =
+      doSomeTransform(original)
+      .build();
 
     assertThat(transformedOrder.status()).isEqualTo(Order.Status.COMPLETE);
+  }
+
+  private static OrderBuilder doSomeTransform(Order original) {
+    OrderBuilder orderBuilder = Order.from(original);
+    if (orderBuilder.status() == Order.Status.NEW) {
+      orderBuilder.status(Order.Status.COMPLETE);
+
+      // transform a nested collection
+      List<OrderLine> newLines = orderBuilder.lines().stream()
+        .filter(line -> line.id() < 43)
+        .toList();
+
+      orderBuilder.lines(newLines);
+    }
+    return orderBuilder;
   }
 }


### PR DESCRIPTION
I'm not sure that this is a good feature. Other builders don't seem to have it. I'm thinking it might be best to remove it until we really really know that we want it?