### PR TITLE
handle generic records

### DIFF
--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordModel.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/RecordModel.java
@@ -16,27 +16,32 @@ import javax.lang.model.type.PrimitiveType;
 
 final class RecordModel {
 
+  // Create a Pattern object
+  private static final Pattern JAVA_UTIL = Pattern.compile("new\\s+(java\\.util\\.[A-Za-z]+)");
+  private static final Pattern OPTIONAL = Pattern.compile("(java\\.util\\.[A-Za-z]+)");
+
   private final TypeElement type;
   private final boolean isImported;
   private final List<? extends RecordComponentElement> components;
 
   private final Set<String> importTypes = new TreeSet<>();
 
-  // Create a Pattern object
-  Pattern JAVA_UTIL = Pattern.compile("new\\s+(java\\.util\\.[A-Za-z]+)");
-  Pattern OPTIONAL = Pattern.compile("(java\\.util\\.[A-Za-z]+)");
-
   RecordModel(
-      TypeElement type, boolean isImported, List<? extends RecordComponentElement> components) {
+      TypeElement type,
+      boolean isImported,
+      List<? extends RecordComponentElement> components,
+      UType utype) {
     this.type = type;
     this.isImported = isImported;
     this.components = components;
     importTypes.add("io.avaje.recordbuilder.Generated");
     importTypes.add("java.util.function.Consumer");
+    var imports = utype.importTypes();
+    imports.remove(type.getQualifiedName().toString());
+    importTypes.addAll(imports);
   }
 
   void initialImports() {
-
     components.stream()
         .map(RecordComponentElement::asType)
         .filter(not(PrimitiveType.class::isInstance))

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/Templates.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/Templates.java
@@ -55,7 +55,6 @@ public class Templates {
 		     public {2}{10} build() '{'
 		         return new {2}{10}({7});
 		     '}'
-
 		   """,
         packageName,
         imports,
@@ -74,6 +73,7 @@ public class Templates {
       CharSequence componentName, String type, String shortName, String typeParams) {
     return MessageFormat.format(
         """
+
 		     /** Set a new value for '{'@code {0}'}'. */
 		     public {2}Builder{3} {0}({1} {0}) '{'
 		         this.{0} = {0};
@@ -86,6 +86,7 @@ public class Templates {
   static String methodGetter(CharSequence componentName, String type, String shortName) {
     return MessageFormat.format(
         """
+
 		     /** Return the current value for '{'@code {0}'}'. */
 		     public {1} {0}() '{'
 		         return {0};

--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/Templates.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/Templates.java
@@ -14,7 +14,9 @@ public class Templates {
       String constructor,
       String constructorBody,
       String builderFrom,
-      String build) {
+      String build,
+      String fullTypeParams,
+      String typeParams) {
 
     return MessageFormat.format(
         """
@@ -24,7 +26,7 @@ public class Templates {
 
 		   /** Builder class for '{'@link {2}'}' */
 		   @Generated("avaje-record-builder")
-		   public class {2}Builder '{'
+		   public class {2}Builder{8} '{'
 		   {3}
 		     private {2}Builder() '{'
 		     '}'
@@ -36,38 +38,49 @@ public class Templates {
 		     /**
 		      * Return a new builder with all fields set to default Java values
 		      */
-		     public static {2}Builder builder() '{'
-		         return new {2}Builder();
+		     public static{9}{2}Builder{10} builder() '{'
+		         return new {2}Builder{10}();
 		     '}'
 
 		     /**
 		      * Return a new builder with all fields set to the values taken from the given record instance
 		      */
-		     public static {2}Builder builder({2} from) '{'
-		         return new {2}Builder({6});
+		     public static{9}{2}Builder{10} builder({2}{10} from) '{'
+		         return new {2}Builder{10}({6});
 		     '}'
 
 		     /**
 		      * Return a new {2} instance with all fields set to the current values in this builder
 		      */
-		     public {2} build() '{'
-		         return new {2}({7});
+		     public {2}{10} build() '{'
+		         return new {2}{10}({7});
 		     '}'
 
 		   """,
-        packageName, imports, shortName, fields, constructor, constructorBody, builderFrom, build);
+        packageName,
+        imports,
+        shortName,
+        fields,
+        constructor,
+        constructorBody,
+        builderFrom,
+        build,
+        fullTypeParams,
+        fullTypeParams.transform(s -> s.isEmpty() ? " " : " " + s + " "),
+        typeParams);
   }
 
-  static String methodSetter(CharSequence componentName, String type, String shortName) {
+  static String methodSetter(
+      CharSequence componentName, String type, String shortName, String typeParams) {
     return MessageFormat.format(
         """
 		     /** Set a new value for '{'@code {0}'}'. */
-		     public {2}Builder {0}({1} {0}) '{'
+		     public {2}Builder{3} {0}({1} {0}) '{'
 		         this.{0} = {0};
 		         return this;
 		     '}'
 		   """,
-        componentName, type, shortName.replace(".", "$"));
+        componentName, type, shortName.replace(".", "$"), typeParams);
   }
 
   static String methodGetter(CharSequence componentName, String type, String shortName) {
@@ -81,32 +94,38 @@ public class Templates {
         componentName, type, shortName.replace(".", "$"));
   }
 
-  static String methodAdd(String componentName, String type, String shortName, String param0) {
+  static String methodAdd(
+      String componentName, String type, String shortName, String param0, String typeParams) {
     String upperCamel = Character.toUpperCase(componentName.charAt(0)) + componentName.substring(1);
     return MessageFormat.format(
         """
 
 		     /** Add new element to the '{'@code {0}'}' collection. */
-		     public {2}Builder add{3}({4} element) '{'
+		     public {2}Builder{5} add{3}({4} element) '{'
 		         this.{0}.add(element);
 		         return this;
 		     '}'
 		   """,
-        componentName, type, shortName.replace(".", "$"), upperCamel, param0);
+        componentName, type, shortName.replace(".", "$"), upperCamel, param0, typeParams);
   }
 
   static String methodPut(
-      String componentName, String type, String shortName, String param0, String param1) {
+      String componentName,
+      String type,
+      String shortName,
+      String param0,
+      String param1,
+      String typeParams) {
     String upperCamel = Character.toUpperCase(componentName.charAt(0)) + componentName.substring(1);
     return MessageFormat.format(
         """
 
 		     /** Add new key/value pair to the '{'@code {0}'}' map. */
-		     public {2}Builder put{3}({4} key, {5} value) '{'
+		     public {2}Builder{6} put{3}({4} key, {5} value) '{'
 		         this.{0}.put(key, value);
 		         return this;
 		     '}'
 		   """,
-        componentName, type, shortName.replace(".", "$"), upperCamel, param0, param1);
+        componentName, type, shortName.replace(".", "$"), upperCamel, param0, param1, typeParams);
   }
 }

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/SomeInterface.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/SomeInterface.java
@@ -1,0 +1,3 @@
+package io.avaje.recordbuilder.test;
+
+public interface SomeInterface {}

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/SomeInterface2.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/SomeInterface2.java
@@ -1,0 +1,3 @@
+package io.avaje.recordbuilder.test;
+
+public interface SomeInterface2 {}

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/Tuple2.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/Tuple2.java
@@ -1,0 +1,6 @@
+package io.avaje.recordbuilder.test;
+
+import io.avaje.recordbuilder.RecordBuilder;
+
+@RecordBuilder
+record Tuple2<T1 extends SomeInterface & SomeInterface2, T2>(T1 t1, T2 t2) {}

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/Tuple2.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/Tuple2.java
@@ -2,5 +2,5 @@ package io.avaje.recordbuilder.test;
 
 import io.avaje.recordbuilder.RecordBuilder;
 
-@RecordBuilder
+@RecordBuilder(getters = true)
 record Tuple2<T1 extends SomeInterface & SomeInterface2, T2>(T1 t1, T2 t2) {}


### PR DESCRIPTION
fixes #24 

given 
```java
@RecordBuilder(getters=true)
record Tuple2<T1 extends SomeInterface & SomeInterface2, T2>(T1 t1, T2 t2) {}
```
will generate:
```java
/** Builder class for {@link Tuple2} */
@Generated("avaje-record-builder")
public class Tuple2Builder<T1 extends SomeInterface & SomeInterface2, T2> {
  private T1 t1;
  private T2 t2;

  private Tuple2Builder() {
  }

  private Tuple2Builder(T1 t1, T2 t2) {
    this.t1 = t1;
    this.t2 = t2;
  }

  /**
   * Return a new builder with all fields set to default Java values
   */
  public static <T1 extends SomeInterface & SomeInterface2, T2> Tuple2Builder<T1, T2> builder() {
      return new Tuple2Builder<T1, T2>();
  }

  /**
   * Return a new builder with all fields set to the values taken from the given record instance
   */
  public static <T1 extends SomeInterface & SomeInterface2, T2> Tuple2Builder<T1, T2> builder(Tuple2<T1, T2> from) {
      return new Tuple2Builder<T1, T2>(from.t1(), from.t2());
  }

  /**
   * Return a new Tuple2 instance with all fields set to the current values in this builder
   */
  public Tuple2<T1, T2> build() {
      return new Tuple2<T1, T2>(t1, t2);
  }

  /** Set a new value for {@code t1}. */
  public Tuple2Builder<T1, T2> t1(T1 t1) {
      this.t1 = t1;
      return this;
  }
  /** Return the current value for {@code t1}. */
  public T1 t1() {
      return t1;
  }
  /** Set a new value for {@code t2}. */
  public Tuple2Builder<T1, T2> t2(T2 t2) {
      this.t2 = t2;
      return this;
  }
  /** Return the current value for {@code t2}. */
  public T2 t2() {
      return t2;
  }
}
```


