### PR TITLE
fix java.lang short types

### DIFF
--- a/avaje-record-builder-core/pom.xml
+++ b/avaje-record-builder-core/pom.xml
@@ -14,7 +14,7 @@
 	</scm>
 	
   <properties>
-    <avaje.prisms.version>1.15</avaje.prisms.version>
+    <avaje.prisms.version>1.16</avaje.prisms.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
currently, types like string are being fully qualified for no reason

requires: https://github.com/avaje/avaje-prisms/pull/28