### PR TITLE
Change Module name to `io.avaje.recordbuilder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Uses Annotation processing to generate builders for records.
 When working with Java modules you need to add the annotation module as a static dependency.
 ```java
 module my.module {
-  requires static io.avaje.record;
+  requires static io.avaje.recordbuilder;
 }
 ```
 ### 2. Add `@RecordBuilder`

--- a/avaje-record-builder-core/src/main/java/module-info.java
+++ b/avaje-record-builder-core/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module io.avaje.record.core {
+module io.avaje.recordbuilder.core {
 
   requires java.compiler;
   requires static io.avaje.prism;

--- a/avaje-record-builder/src/main/java/module-info.java
+++ b/avaje-record-builder/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module io.avaje.record {
+module io.avaje.recordbuilder {
 
   exports io.avaje.recordbuilder;
 }

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/ArmoredCore.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/ArmoredCore.java
@@ -1,9 +1,0 @@
-package io.avaje.recordbuilder.test;
-
-import io.avaje.recordbuilder.DefaultValue;
-
-public record ArmoredCore(
-    @DefaultValue("\"Steel Haze\"") String coreName,
-    String model,
-    int energyReserve,
-    int ap) {}

--- a/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/ArmoredCore.java
+++ b/blackbox-test-records/src/main/java/io/avaje/recordbuilder/test/ArmoredCore.java
@@ -1,0 +1,9 @@
+package io.avaje.recordbuilder.test;
+
+import io.avaje.recordbuilder.DefaultValue;
+
+public record ArmoredCore(
+    @DefaultValue("\"Steel Haze\"") String coreName,
+    String model,
+    int energyReserve,
+    int ap) {}

--- a/blackbox-test-records/src/main/java/module-info.java
+++ b/blackbox-test-records/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module io.avaje.spi.blackbox {
-  requires io.avaje.record;
+  requires io.avaje.recordbuilder;
   requires io.avaje.validation.contraints;
   requires java.compiler;
 }


### PR DESCRIPTION
`io.avaje.record` is quite undescriptive. (also it seems the module validation has `io.avaje.recordbuilder` as the module name)