### PR TITLE
Fail compilation if `requires static` is not used in modular projects

### DIFF
--- a/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/ModuleReader.java
+++ b/avaje-record-builder-core/src/main/java/io/avaje/recordbuilder/internal/ModuleReader.java
@@ -1,5 +1,6 @@
 package io.avaje.recordbuilder.internal;
 
+import static io.avaje.recordbuilder.internal.APContext.logError;
 import static io.avaje.recordbuilder.internal.APContext.logWarn;
 
 import java.io.BufferedReader;
@@ -21,7 +22,7 @@ final class ModuleReader {
               }
 
               if (line.contains("io.avaje.recordbuilder") && !line.contains("static")) {
-                logWarn(
+                logError(
                     "`requires io.avaje.recordbuilder` should be `requires static io.avaje.recordbuilder`",
                     module);
               }

--- a/blackbox-test-records/src/main/java/module-info.java
+++ b/blackbox-test-records/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module io.avaje.spi.blackbox {
-  requires io.avaje.recordbuilder;
+  requires static io.avaje.recordbuilder;
   requires io.avaje.validation.contraints;
   requires java.compiler;
 }


### PR DESCRIPTION
Another foot gun removed.